### PR TITLE
SCI 32 Admin Enable remote download of dbs

### DIFF
--- a/src/fastapi_server.py
+++ b/src/fastapi_server.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from src.routers import (
     classify_page_entrypoints,
+    db_router,
     face_managment,
     face_processing,
     groups_page_entrypoints,
@@ -22,7 +23,6 @@ from .services.groups_db import GROUPED_FILE
 from .services.redis_service import RedisInterface
 
 app_config = AppConfig()
-app_config = AppConfig()
 app = FastAPI()
 
 PICKLE_FILE = "/data/image_metadata.pkl"
@@ -33,11 +33,15 @@ BASE_PATH = "/images"
 redis_service = None
 face_recognition_service = None
 
+db_router = db_router.DbRouter(image_db_path=PICKLE_FILE, groups_db_path=GROUPED_FILE)
+db_router.create_entry_points(app)
+
 face_db_service = FaceDBService(db_path=FACE_DB)
 
 classify_router = classify_page_entrypoints.ClassifyRouter(
     face_db_service=face_db_service
 )
+
 classify_router.create_entry_points(app)
 
 groups_router = groups_page_entrypoints.GroupsRouter()

--- a/src/routers/db_router.py
+++ b/src/routers/db_router.py
@@ -1,0 +1,52 @@
+from fastapi import FastAPI
+from fastapi.responses import FileResponse
+
+
+class DbRouter:
+    def __init__(self, image_db_path: str, groups_db_path: str):
+        """
+        Initialize the DbRouter with paths to the image and groups databases.
+        """
+        self._image_db = image_db_path
+        self._groups_db = groups_db_path
+
+    def create_entry_points(self, app: FastAPI):
+        """
+        Create the endpoints for downloading the image and groups databases.
+        """
+
+        @app.get(
+            "/download/images_db",
+            description="Download Images DB",
+            response_class=FileResponse,
+        )
+        def get_images_db():
+            """
+            Endpoint to download the images database file.
+            """
+            return FileResponse(
+                path=self._image_db,
+                filename="images.db",
+                media_type="application/octet-stream",
+            )
+
+        @app.get(
+            "/download/groups_db",
+            description="Download Groups DB",
+            response_class=FileResponse,
+        )
+        def get_groups_db():
+            """
+            Endpoint to download the groups database file.
+            """
+            return FileResponse(
+                path=self._groups_db,
+                filename="groups.db",
+                media_type="application/octet-stream",
+            )
+
+
+# Example usage:
+# app = FastAPI()
+# db_router = DbRouter(image_db_path="/path/to/images.db", groups_db_path="/path/to/groups.db")
+# db_router.create_entry_points(app)


### PR DESCRIPTION
### Pull Request Title:  
Add Database Router for Download Endpoints and Update Server Configuration

### Description:  
- **New Feature**: Added a `DbRouter` class in `src/routers/db_router.py` to enable downloading of the image and groups databases via FastAPI endpoints:
  - `/download/images_db`: Provides access to the image database file.
  - `/download/groups_db`: Provides access to the groups database file.
- **Server Updates**: 
  - Integrated the `DbRouter` into `fastapi_server.py`, ensuring the new endpoints are registered with the FastAPI application.
  - Adjusted server logic to accommodate `DbRouter` initialization.
- **Miscellaneous**: Ensured file formatting standards in `groups_db.py` by maintaining compatibility with existing functionality.