### PR TITLE
Sci 35 add group field to images

### DIFF
--- a/src/fastapi_server.py
+++ b/src/fastapi_server.py
@@ -127,17 +127,17 @@ async def start_fastapi_server():
 
 async def perform_migration():
     # Check if both files exist, exit if either is missing
-    group_db = Path(GROUPED_FILE)
-    pickle_file = Path(PICKLE_FILE)
+    group_db = Path(GROUP_DB)
+    pickle_file = Path(IMAGE_DB)
     if not (pickle_file.exists() and group_db.exists()):
         return
-    backup_path = Path("/data") / "backup-0.10.0"
+    backup_path = Path("/data") / "backup-0.11.0"
     if backup_path.exists():
         return
     logger.info("Updating software databases...")
 
-    backup_group_path = backup_path / "group.pkl"
-    backup_images_path = backup_path / "images.pkl"
+    backup_group_path = backup_path / "group_db.json"
+    backup_images_path = backup_path / "image_db.json"
 
     logger.info("Backing up old db...")
     # Create backup_path as a folder
@@ -150,11 +150,8 @@ async def perform_migration():
     shutil.copy(group_db, backup_group_path)
     logger.info("Starting migration...")
     # Perform database migration
-    await db_router.migrate_groups_db()
+    await db_router.update_group_field_in_images()
 
-    # Delete PICKLE_FILE and GROUP_DB
-    pickle_file.unlink()
-    group_db.unlink()
     logger.info("Finished Migration")
 
 

--- a/src/routers/db_router.py
+++ b/src/routers/db_router.py
@@ -82,10 +82,6 @@ class DbRouter:
                 media_type="application/octet-stream",
             )
 
-        @app.post("/scripts/migrate/groups_db", tags=["DB Managment"])
-        async def migrate_groups_db_entrypoint():
-            await self.migrate_groups_db()
-
     async def migrate_groups_db(self):
         """
         Migrates data from a pickle file containing GroupMetadata_V1 objects to new

--- a/src/routers/db_router.py
+++ b/src/routers/db_router.py
@@ -152,6 +152,19 @@ class DbRouter:
                 detail=f"An error occurred during migration: {e}",
             )
 
+    async def update_group_field_in_images(self):
+        groups = self._groups_db_service.get_groups()
+
+        for group in tqdm(groups):
+            if group.group_name.lower() == "Unknown":
+                continue
+            images_details = self._image_db_service.get_images(
+                query={"full_client_path": {"$in": group.list_of_images}}
+            )
+            for image in tqdm(images_details):
+                image.group_name = group.group_name
+                self._image_db_service.add_image(image)
+
 
 # Example usage:
 # app = FastAPI()

--- a/src/routers/db_router.py
+++ b/src/routers/db_router.py
@@ -9,7 +9,12 @@ from tqdm import tqdm
 from src.services.groups_db import load_groups_from_pickle_file
 from src.services.groups_db_service import GroupDBService
 from src.services.images_db_service import ImageDBService
-from src.utils.model_pydantic import GroupMetadata, GroupMetadata_V1, ImageMetadata
+from src.utils.model_pydantic import (
+    GroupMetadata,
+    GroupMetadata_V1,
+    ImageFaceRecognitionStatus,
+    ImageMetadata,
+)
 
 
 class DBType(str, Enum):
@@ -163,6 +168,8 @@ class DbRouter:
             )
             for image in tqdm(images_details):
                 image.group_name = group.group_name
+                if image.face_recognition_status == ImageFaceRecognitionStatus.FAILED:
+                    image.face_recognition_status == ImageFaceRecognitionStatus.RETRY
                 self._image_db_service.add_image(image)
 
 

--- a/src/routers/face_managment.py
+++ b/src/routers/face_managment.py
@@ -181,6 +181,7 @@ class FaceManagmentRouter:
             ]
             selected_face.ron_in_face = not selected_face.ron_in_face
             self._face_db_service.add_face(selected_face, flush=True)
+            # TODO: Update image and face with the information
             return selected_face.ron_in_face
 
         @app.post("/face/{face_id}/hide", tags=["Face Management"])

--- a/src/routers/groups_page_entrypoints.py
+++ b/src/routers/groups_page_entrypoints.py
@@ -287,6 +287,9 @@ class GroupsRouterV2(GroupsRouterV1):
                 if not group.list_of_images:
                     return JSONResponse(content={"images": []}, status_code=200)
 
+                # Update the group as saw
+                self._group_db_service.saw_group_images(group_name=group_name)
+
                 # Fetch the detailed metadata for all images in the group
                 images_details = self._image_db_service.get_images(
                     query={"full_client_path": {"$in": group.list_of_images}}

--- a/src/services/face_reid.py
+++ b/src/services/face_reid.py
@@ -266,7 +266,7 @@ class FaceRecognitionService:
                 )
                 | (
                     query.face_recognition_status
-                    == ImageFaceRecognitionStatus.FAILED.value
+                    == ImageFaceRecognitionStatus.RETRY.value
                 )
             )
 

--- a/src/services/groups_db_service.py
+++ b/src/services/groups_db_service.py
@@ -169,6 +169,8 @@ class GroupDBService:
                 )
                 return False
             group.list_of_images.append(image_path)
+            if group.selection == "interesting":
+                group.has_new_image = True
             self.add_group(group, flush=flush)
             return True
         return False
@@ -196,6 +198,14 @@ class GroupDBService:
             self.add_group(group, flush=flush)
             return True
         return False
+
+    def saw_group_images(self, group_name):
+        group_data = self.db.get(Query().group_name == group_name)
+        if group_data:
+            group = GroupMetadata(**group_data)
+            if group.selection == "interesting":
+                group.has_new_image = False
+            self.add_group(group)
 
     def save_db(self):
         self.db.storage.flush()

--- a/src/utils/model_pydantic.py
+++ b/src/utils/model_pydantic.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel, Field
 class ImageFaceRecognitionStatus(str, Enum):
     PENDING = "pending"
     FAILED = "failed"
+    RETRY = "retry"
     DONE = "done"
 
 

--- a/src/utils/model_pydantic.py
+++ b/src/utils/model_pydantic.py
@@ -36,6 +36,7 @@ class GroupMetadata(BaseModel):
         "unprocessed"  # Can be "unprocessed", "interesting", or "not interesting"
     )
     ron_in_group: Optional[bool] = False
+    has_new_image: Optional[bool] = False
 
     @property
     def image_count(self):

--- a/src/utils/model_pydantic.py
+++ b/src/utils/model_pydantic.py
@@ -24,6 +24,7 @@ class ImageMetadata(BaseModel):
     face_recognition_status: Optional[
         ImageFaceRecognitionStatus
     ] = ImageFaceRecognitionStatus.PENDING
+    group_name: Optional[str] = "Unknown"
 
 
 class GroupMetadata(BaseModel):

--- a/src/utils/model_pydantic.py
+++ b/src/utils/model_pydantic.py
@@ -34,6 +34,7 @@ class GroupMetadata(BaseModel):
     selection: str = (
         "unprocessed"  # Can be "unprocessed", "interesting", or "not interesting"
     )
+    ron_in_group: Optional[bool] = False
 
     @property
     def image_count(self):


### PR DESCRIPTION
### Pull Request Title  
**[SCI-35] Database Migration and Group Updates**

### Summary of Changes  
- **Migration Updates**:  
  - Updated database file paths to `group_db.json` and `image_db.json`.  
  - New backup directory: `/data/backup-0.11.0`.  
  - Removed old database cleanup step during migration.  

- **Group and Image Updates**:  
  - Added `update_group_field_in_images()` for correcting "Unknown" group assignments and retrying failed face recognition.  
  - Added tracking for "interesting" groups with new images (`has_new_image` field).  
  - Deprecated `migrate_groups_db_entrypoint()`.  

- **Metadata Changes**:  
  - Added `group_name` field to `ImageMetadata` and `ron_in_group`/`has_new_image` fields to `GroupMetadata`.  

- **Miscellaneous**:  
  - Enabled marking groups as "viewed" with `saw_group_images()`.  
  - Adjusted retry handling in face recognition service.  

### Impact  
- Improved database migration flow.  
- Enhanced group and image management logic.  
- Metadata updates ensure better tracking and consistency.

[SCI-35]: https://mozicobv.atlassian.net/browse/SCI-35?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ