### PR TITLE
Sci 34 create a script to copy the images based on class os copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.16.0 (2025-01-05)
+
+### Feat
+
+- **ImagesProcessingV2**: Create an entrypoint to copy tagged images
+
+### Refactor
+
+- **fastapi_server**: Pass /data directory to ImagesProcessingV2 as data_base_path
+
 ## 0.15.0 (2025-01-05)
 
 ### Feat

--- a/cz.toml
+++ b/cz.toml
@@ -2,5 +2,5 @@
 name = "cz_conventional_commits"
 tag_format = "$version"
 version_scheme = "pep440"
-version = "0.15.0"
+version = "0.16.0"
 update_changelog_on_bump = true

--- a/src/fastapi_server.py
+++ b/src/fastapi_server.py
@@ -62,6 +62,7 @@ groups_router.create_entry_points(app)
 
 image_router = image_managment.ImagesProcessingV2(
     images_base_path=BASE_PATH,
+    data_base_path="/data",
     group_db_service=group_db_service,
     image_db_service=image_db_service,
 )


### PR DESCRIPTION
**Pull Request Title:**  
Feature: Copy Tagged Images and Refactor Path Management

**Summary:**  
This PR introduces a new feature to streamline the handling of tagged images and optimizes path management for the `ImagesProcessingV2` service.

**Changes:**

**Features:**  
- Added an endpoint (`/v2/copy_images`) in `ImagesProcessingV2` to copy tagged images based on their classification into dedicated folders.  
- Introduced `ClassificationMetadata` and `CopyImagesStatus` models to manage and monitor the copying process.  

**Refactor:**  
- Passed the `/data` directory as `data_base_path` to `ImagesProcessingV2`, improving flexibility in managing file paths.  
- Added functionality to dynamically create folders for image categories before copying images.  

**Versioning:**  
- Updated the project version from `0.15.0` to `0.16.0` in `cz.toml`.  
- Documented changes in `CHANGELOG.md` under version `0.16.0`.  