### PR TITLE
Mozicobv/moz 54 classify only groups up to 11092022 are shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.17.1 (2025-01-28)
+
+## 0.16.1 (2025-01-28)
+
+### Fix
+
+- **images.js**: Set the page_size to 400 in when fetching groups
+
 ## 0.17.0 (2025-01-08)
 
 ### Feat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.16.1 (2025-01-28)
+
+### Fix
+
+- **images.js**: Set the page_size to 400 in when fetching groups
+
 ## 0.16.0 (2025-01-05)
 
 ### Feat

--- a/cz.toml
+++ b/cz.toml
@@ -2,5 +2,5 @@
 name = "cz_conventional_commits"
 tag_format = "$version"
 version_scheme = "pep440"
-version = "0.16.0"
+version = "0.16.1"
 update_changelog_on_bump = true

--- a/cz.toml
+++ b/cz.toml
@@ -2,5 +2,5 @@
 name = "cz_conventional_commits"
 tag_format = "$version"
 version_scheme = "pep440"
-version = "0.17.0"
+version = "0.17.1"
 update_changelog_on_bump = true

--- a/src/static/js/images.js
+++ b/src/static/js/images.js
@@ -29,7 +29,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
 async function fetchGroups() {
     try {
-        const response = await fetch(`/get_groups_paginated?page=1&page_size=100&filter_selections=interesting`);
+        const response = await fetch(`/get_groups_paginated?page=1&page_size=400&filter_selections=interesting`);
         if (!response.ok) {
             throw new Error('Failed to fetch group data');
         }


### PR DESCRIPTION
**Pull Request Title:**  
Fix Group Pagination Settings in Frontend

**Summary:**  
This PR addresses a frontend issue by adjusting the pagination settings to fetch a larger number of groups in a single request, ensuring improved performance and data retrieval consistency.

**Changes:**

**Fixes:**  
- Updated `images.js` to increase the `page_size` parameter from 100 to 400 in the `fetchGroups` function, allowing more groups to be fetched per request.  

**Versioning:**  
- Incremented project version from `0.17.0` to `0.17.1`.  
- Documented the fix in `CHANGELOG.md` under version `0.17.1`.  